### PR TITLE
[KOB-8068] Installing popup doesn’t disappear after the app was installed. (iOS 10.3 only)

### DIFF
--- a/src/installation_proxy.c
+++ b/src/installation_proxy.c
@@ -366,10 +366,6 @@ static instproxy_error_t instproxy_receive_status_loop(instproxy_client_t client
 
 			/* check status from response */
 			instproxy_status_get_name(node, &status_name);
-			if (!status_name) {
-				debug_info("failed to retrieve name from status response with error %d.", res);
-				complete = 1;
-			}
 
 			if (status_name) {
 				if (!strcmp(status_name, "Complete")) {


### PR DESCRIPTION
In IOS **10.3**, the app was installed is not completed. 
![image](https://user-images.githubusercontent.com/28770495/81269808-11f38700-9074-11ea-8e05-b2edadd02116.png)
That's why the installing popup doesn't disappear, the browser doesn't get the message from the web socket to update the status.

I find and apply the solution from https://github.com/libimobiledevice/ideviceinstaller/issues/70 and it work